### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -36,7 +36,7 @@ mkdir package
 mkdir lib
 
 # Pull down Python dependencies
-pip3 install -r requirements.txt -t lib --no-binary fuzzywuzzy,python-dateutil,pytz,paho-mqtt,requests --prefix ""
+pip3 install -r requirements.txt -t lib --no-binary rapidfuzz,python-dateutil,pytz,paho-mqtt,requests --prefix ""
 
 cp -r pkg lib requirements.txt package.sh snips.tar sounds LICENSE *.json *.py package/
 find package -type f -name '*.pyc' -delete

--- a/pkg/intentions.py
+++ b/pkg/intentions.py
@@ -39,10 +39,10 @@ from subprocess import call
 #    print("ERROR, hermes is not installed. try 'pip3 install hermes-python'")
 
 try:
-    from fuzzywuzzy import fuzz
-    from fuzzywuzzy import process
+    from rapidfuzz import fuzz
+    from rapidfuzz import process
 except:
-    print("ERROR, fuzzywuzzy is not installed. try 'pip3 install fuzzywuzzy'")
+    print("ERROR, rapidfuzz is not installed. try 'pip3 install rapidfuzz'")
 
 try:
     import alsaaudio

--- a/pkg/voco_adapter.py
+++ b/pkg/voco_adapter.py
@@ -57,10 +57,10 @@ except:
     print("ERROR, paho is not installed. try 'pip3 install paho'")
 
 try:
-    from fuzzywuzzy import fuzz
-    from fuzzywuzzy import process
+    from rapidfuzz import fuzz
+    from rapidfuzz import process
 except:
-    print("ERROR, fuzzywuzzy is not installed. try 'pip3 install fuzzywuzzy'")
+    print("ERROR, rapidfuzz is not installed. try 'pip3 install rapidfuzz'")
 
 try:
     import alsaaudio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fuzzywuzzy
+rapidfuzz
 pyalsaaudio
 python-dateutil
 pytz


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefore MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.